### PR TITLE
fix missing configs; resolves #30

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/alpaca_farm/auto_annotations/annotators *

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setuptools.setup(
     version=version,
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),
+    package_data={"": ["alpaca_farm/auto_annotations/annotators/*/*.yaml"]},
+    include_package_data=True,
     install_requires=[
         "datasets",
         "einops",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setuptools.setup(
     version=version,
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),
-    package_data={"": ["alpaca_farm/auto_annotations/annotators/*/*.yaml"]},
     include_package_data=True,
     install_requires=[
         "datasets",


### PR DESCRIPTION
I didn't follow up on this for a week, since was expecting we'd get a quick swap in with AlpacaEval. But the AlpacaEval release was delayed, and it seems we won't get the upgrade soon, so I'm manually patching this issue now. 

@YannDubs 