### PR TITLE
[BREAKING] 003 depreciation: changing autoannotators to AlpacaEval 1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-**Changing auto-annotators**: `text-davinci-003` is [now depreciated](https://platform.openai.com/docs/deprecations) by OpenAI, as a result we can't use the original pool of annotators for automatically generating preferences (for fine-tuning or evaluation). We therefore switched to the GPT-4 annotator from [AlpacaEval 1](https://github.com/tatsu-lab/alpaca_eval). All results should thus be compared to models from AlpacaEval 1 rather than the original AlpacaFarm results. Note that overoptimization might not be seen in this new setting (see Figure 4 in the [paper](https://arxiv.org/abs/2305.14387)). We are sorry for the invonvenience caused.
+**Changing auto-annotators**: `text-davinci-003` is [now depreciated](https://platform.openai.com/docs/deprecations) by OpenAI, as a result we can't use the original pool of annotators for automatically generating preferences (for fine-tuning or evaluation). We therefore switched to the GPT-4 annotator from [AlpacaEval 1](https://github.com/tatsu-lab/alpaca_eval). All results should thus be compared to models from AlpacaEval 1 rather than the original AlpacaFarm results. Note that over-optimization might not be seen in this new setting (see Figure 4 in the [paper](https://arxiv.org/abs/2305.14387)). We are sorry for the inconvenience caused.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-**Changing auto-annotators**: `text-davinci-003` is [now depreciated](https://platform.openai.com/docs/deprecations) by OpenAI, as a result we can't use the original pool of annotators for automatically generating preferences (for fine-tuning or evaluation). We therefore switched to the GPT-4 annotator from [AlpacaEval 1](https://github.com/tatsu-lab/alpaca_eval). All results should thus be compared to models from AlpacaEval 1 rather than the original AlpacaFarm results. Note that over-optimization might not be seen in this new setting (see Figure 4 in the [paper](https://arxiv.org/abs/2305.14387)). We are sorry for the inconvenience caused.
+**Changing auto-annotators**: `text-davinci-003` is [now depreciated](https://platform.openai.com/docs/deprecations) by OpenAI, as a result, we can't use the original pool of annotators for automatically generating preferences (for fine-tuning or evaluation). We, therefore, switched to the GPT-4 annotator from [AlpacaEval 1](https://github.com/tatsu-lab/alpaca_eval). All results should thus be compared to models from AlpacaEval 1 rather than the original AlpacaFarm results. Note that over-optimization might not be seen in this new setting (see Figure 4 in the [paper](https://arxiv.org/abs/2305.14387)). We are sorry for the inconvenience caused.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,21 +156,15 @@ path_to_outputs = "examples/data/eval_gpt-3.5-turbo-0301.json"
 # [{'instruction': 'What are the names of some famous actors that started their careers on Broadway?', 'input': '', 'output': 'Some famous actors that started their careers on Broadway are Hugh Jackman, Meryl Streep, Denzel Washington, Audra McDonald, and Lin-Manuel Miranda.', 'generator': 'gpt-3.5-turbo-0301', 'dataset': 'helpful_base', 'datasplit': 'eval'},
 # ...]
 
-alpaca_leaderboard(path_or_all_outputs=path_to_outputs, name="My fancy model", is_print_metrics=True)
-#                      n_draws  n_total  n_wins  n_wins_base  standard_error  win_rate
-# GPT4                   17.00   804.00  631.00       156.00            1.40     79.54
-# ChatGPT                 9.00   805.00  503.00       293.00            1.69     63.04
-# My fancy model          9.00   803.00  497.00       297.00            1.70     62.45
-# RLHF PPO                9.00   805.00  392.00       404.00            1.75     49.25
-# SFT 52k (Alpaca 7B)    16.00   805.00  312.00       477.00            1.71     39.75
-# SFT 10k                19.00   802.00  278.00       505.00            1.67     35.85
-# Davinci001              0.00   805.00  201.00       604.00            1.53     24.97
-# LLaMA 7B                0.00   775.00   98.00       677.00            1.19     12.65
+alpaca_leaderboard(path_to_outputs, name="My fancy model")
+#                               win_rate  standard_error  n_total  avg_length
+# gpt35_turbo_instruct             81.71            1.33      801        1018
+# alpaca-farm-ppo-sim-gpt4-20k     44.10            1.74      805         511
+# My fancy model                   41.54            2.01      597         327
+# alpaca-farm-ppo-human            41.24            1.73      805         803
+# alpaca-7b                        26.46            1.54      805         396
+# text_davinci_001                 15.17            1.24      804         296
 ```
-
-If you want to compare against our baseline model (Davinci003 with
-our [prompt](https://github.com/tatsu-lab/alpaca_farm/blob/main/examples/prompts/v0_inputs_noinputs.json)) on your own
-data, you can decode it using [main_oai_baselines](#openai-models).
 
 ## Running reference methods
 
@@ -375,5 +369,18 @@ Please consider citing our work if you use the data or code in this repo.
       eprint={2305.14387},
       archivePrefix={arXiv},
       primaryClass={cs.LG}
+}
+```
+
+If you use `alpaca-farm>=0.2.0` make sure to specify that the annotator changed (as `text-davinci-003` is depreciated). The preferences and win-rates are now from AlpacaEval 1 and are not comparable to the numbers from our paper. You can cite AlpacaEval as:
+
+```
+@misc{alpaca_eval,
+  author = {Xuechen Li and Tianyi Zhang and Yann Dubois and Rohan Taori and Ishaan Gulrajani and Carlos Guestrin and Percy Liang and Tatsunori B. Hashimoto },
+  title = {AlpacaEval: An Automatic Evaluator of Instruction-following Models},
+  year = {2023},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/tatsu-lab/alpaca_eval}}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+
+**Changing auto-annotators**: `text-davinci-003` is [now depreciated](https://platform.openai.com/docs/deprecations) by OpenAI, as a result we can't use the original pool of annotators for automatically generating preferences (for fine-tuning or evaluation). We therefore switched to the GPT-4 annotator from [AlpacaEval 1](https://github.com/tatsu-lab/alpaca_eval). All results should thus be compared to models from AlpacaEval 1 rather than the original AlpacaFarm results. Note that overoptimization might not be seen in this new setting (see Figure 4 in the [paper](https://arxiv.org/abs/2305.14387)). We are sorry for the invonvenience caused.
+
+---
+
 Research and development on learning from human feedback is difficult because methods
 like [RLHF](https://arxiv.org/abs/2203.02155) are complex and costly to run.
 AlpacaFarm is a simulator that enables research and development on learning from feedback at a fraction of the usual

--- a/examples/auto_annotations.ipynb
+++ b/examples/auto_annotations.ipynb
@@ -9,6 +9,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "521a7025-81f7-45e0-a8ee-8454f2e5e01a",
+   "metadata": {},
+   "source": [
+    "Note: AlpacaFarm now uses [AlpacaEval 1](https://github.com/tatsu-lab/alpaca_eval/tree/main). For annotations and evaluations, since `text-davinci-003` has been depreciated by OpenAI."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "f9ee20f0-007c-4f6a-af1c-ad39b959984b",
@@ -40,27 +48,7 @@
    "metadata": {},
    "source": [
     "All of our annotators currently use OpenAI API. So the first step is to setup your OpenAI key (and potentially your organization). This can be done by either running setting your environment variable like \n",
-    "- `export OPENAI_API_KEY=\"sk...\"` \n",
-    "\n",
-    "or by setting the following python variables:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "160c6cd6-dbb5-49ab-a286-344ce2e87308",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "if 'OPENAI_API_KEY' not in os.environ:\n",
-    "    decoding_kwargs = dict(\n",
-    "        openai_api_key = None, #\"sk-...\",\n",
-    "        openai_organization_ids = None, # [\"org-...\",\"org-...\"] you can set multiple orgs to avoid rate limits\n",
-    "    )\n",
-    "    assert decoding_kwargs[\"openai_api_key\"] is not None, \"OPENAI_API_KEY not found you should set it in environment or above\"\n",
-    "else:\n",
-    "    decoding_kwargs = {}"
+    "- `export OPENAI_API_KEY=\"sk...\"` "
    ]
   },
   {
@@ -68,14 +56,12 @@
    "id": "c9b8222f-c017-4aae-9b29-cc8210e946fe",
    "metadata": {},
    "source": [
-    "The key object that you need for automatic annotations (both for training or for eval) is our `PairwiseAutoAnnotator` which inherits from [AlapcaEval's `PairwiseAnnotator`](https://github.com/tatsu-lab/alpaca_eval/blob/main/src/alpaca_eval/annotators/pairwise_evaluator.py#L20). By default the annotator is the pool from Alpaca Farm, for simplicity let's use a single annotator `test` for now.\n",
-    "\n",
-    "For an overview annotators including how to extend them (different model such as ChatGPT or GPT4, prompts, decoding parameters), refer to the [Configuring annotators](#Configuring-annotators) section of this notebook. For more details refer to [AlpacaEval](https://github.com/tatsu-lab/alpaca_eval/tree/main)."
+    "The key object that you need for automatic annotations (both for training or for eval) is the `PairwiseAutoAnnotator`, which is a minor wrapper around [AlapcaEval's `PairwiseAnnotator`](https://github.com/tatsu-lab/alpaca_eval/blob/main/src/alpaca_eval/annotators/pairwise_evaluator.py#L20) (wrapper to deal with separate instruction and input). "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "32d6dcf4-b0fb-4c56-a1fd-1db509af05e9",
    "metadata": {},
    "outputs": [
@@ -83,9 +69,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:Creating the annotator from `test`.\n",
-      "INFO:root:Saving annotations to `/Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json`.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n"
+      "INFO:root:Creating the annotator from `alpaca_eval_gpt4`.\n",
+      "INFO:root:Saving annotations to `/Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json`.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n"
      ]
     }
    ],
@@ -93,7 +79,7 @@
     "from alpaca_farm.utils import jload\n",
     "from alpaca_farm.auto_annotations import PairwiseAutoAnnotator\n",
     "\n",
-    "annotator = PairwiseAutoAnnotator(annotators_config=\"test\", **decoding_kwargs)"
+    "annotator = PairwiseAutoAnnotator(annotators_config=\"alpaca_eval_gpt4\")"
    ]
   },
   {
@@ -114,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "7ab42c1d-3bda-4797-a1bd-877b958e8657",
    "metadata": {},
    "outputs": [
@@ -135,7 +121,7 @@
        "  'output_2': \"Hey everyone! \\n\\nI'm hosting a dinner party this Friday night and I'd love for all of you to come over. We'll have a delicious spread of food and some great conversations. \\n\\nLet me know if you can make it - I'd love to see you all there!\\n\\nCheers,\\n[Your Name]\"}]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "67caa934-5a37-429a-affc-dbd182be7c40",
    "metadata": {},
    "outputs": [
@@ -156,9 +142,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:Annotating 0 examples with davinci003_3\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n"
+      "Annotation chunk:   0%|                                                       | 0/1 [00:00<?, ?it/s]INFO:root:Annotating 6 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Using `openai_completions` on 6 prompts using gpt-4.\n",
+      "INFO:root:Kwargs to completion: {'model': 'gpt-4', 'is_chat': True, 'temperature': 0}. num_procs=5\n",
+      "\n",
+      "prompt_batches:   0%|                                                         | 0/6 [00:00<?, ?it/s]\u001b[AINFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches:  17%|████████▏                                        | 1/6 [00:03<00:16,  3.38s/it]\u001b[AINFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches:  33%|████████████████▎                                | 2/6 [00:04<00:07,  1.78s/it]\u001b[AINFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches: 100%|█████████████████████████████████████████████████| 6/6 [00:04<00:00,  1.29it/s]\u001b[A\n",
+      "INFO:root:Completed 6 examples in 4.8 seconds.\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 1/1 [00:06<00:00,  6.59s/it]\n"
      ]
     }
    ],
@@ -168,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "1dd953df-7eb1-4446-86a9-f3b3fbfba665",
    "metadata": {},
    "outputs": [
@@ -179,11 +186,14 @@
        "  'input': '',\n",
        "  'output_1': \"Dear Friends, \\r\\n\\r\\nI hope this message finds you well. I'm excited to invite you to dinner on Friday. We'll meet at 7:00 PM at [location]. I look forward to seeing you there. \\r\\n\\r\\nBest,\\r\\n[Name]\",\n",
        "  'output_2': \"Hey everyone! \\n\\nI'm hosting a dinner party this Friday night and I'd love for all of you to come over. We'll have a delicious spread of food and some great conversations. \\n\\nLet me know if you can make it - I'd love to see you all there!\\n\\nCheers,\\n[Your Name]\",\n",
-       "  'annotator': 'davinci003_3',\n",
-       "  'preference': 1}]"
+       "  'annotator': 'alpaca_eval_gpt4',\n",
+       "  'preference': 2.0,\n",
+       "  'price_per_example': 0.012989999999999998,\n",
+       "  'time_per_example': 0.8035085201263428,\n",
+       "  'raw_completion': \"[\\n    {'model': 'model_1', 'rank': 1},\\n    {'model': 'model_2', 'rank': 2}\\n]\"}]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -225,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "e2a9cce3-0fe9-4dc2-9b49-de59f641e170",
    "metadata": {},
    "outputs": [
@@ -245,7 +255,7 @@
        "  'output': \"Dear Friends, \\r\\n\\r\\nI hope this message finds you well. I'm excited to invite you to dinner on Friday. We'll meet at 7:00 PM at [location]. I look forward to seeing you there. \\r\\n\\r\\nBest,\\r\\n[Name]\"}]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "1f808315-da5c-4af3-a026-64e3d07801f3",
    "metadata": {},
    "outputs": [
@@ -278,7 +288,7 @@
        "  'output': 'Dear Friends, \\n\\nI am writing to invite you all to a dinner on Friday evening. It is a casual affair, and I am looking forward to a fun evening catching up with you all. I am planning to make a selection of delicious dishes, ranging from appetizers to mains and desserts. There will be something for everyone to enjoy, and I am sure it will be a night to remember.\\n\\nThe dinner will be held at my place on Friday, April 17th at 7pm. If you are interested in joining me, please RSVP to this email by Thursday, April 16th. I am looking forward to seeing you all there! \\n\\nThank you, \\n\\n[Name]'}]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -299,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "e613e0ca-2db8-436c-a4c7-bf71de116ae0",
    "metadata": {},
    "outputs": [
@@ -307,9 +317,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:Annotating 0 examples with davinci003_3\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n"
+      "Annotation chunk:   0%|                                                       | 0/1 [00:00<?, ?it/s]INFO:root:Annotating 6 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Using `openai_completions` on 6 prompts using gpt-4.\n",
+      "INFO:root:Kwargs to completion: {'model': 'gpt-4', 'is_chat': True, 'temperature': 0}. num_procs=5\n",
+      "\n",
+      "prompt_batches:   0%|                                                         | 0/6 [00:00<?, ?it/s]\u001b[AINFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches:  17%|████████▏                                        | 1/6 [00:03<00:18,  3.66s/it]\u001b[AINFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches:  67%|████████████████████████████████▋                | 4/6 [00:03<00:01,  1.37it/s]\u001b[AINFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches: 100%|█████████████████████████████████████████████████| 6/6 [00:04<00:00,  1.43it/s]\u001b[A\n",
+      "INFO:root:Completed 6 examples in 4.4 seconds.\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 1/1 [00:06<00:00,  6.07s/it]\n"
      ]
     }
    ],
@@ -319,22 +350,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "a72e4e7a-cd40-41c3-87b7-995e323e35d4",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{'instruction': 'The sentence you are given might be too wordy, complicated, or unclear. Rewrite the sentence and make your writing clearer by keeping it concise. Whenever possible, break complex sentences into multiple sentences and eliminate unnecessary words.',\n",
+       "[{'instruction': 'The sentence you are given might be too wordy, complicated, or unclear. Rewrite the sentence and make your writing clearer by keeping it concise. Whenever possible, break complex sentences into multiple sentences and eliminate unnecessary words.\\n\\nIf you have any questions about my rate or if you find it necessary to increase or decrease the scope for this project, please let me know.',\n",
        "  'input': 'If you have any questions about my rate or if you find it necessary to increase or decrease the scope for this project, please let me know.',\n",
        "  'output_1': 'If you have questions about my rate or need to modify the scope of this project, please let me know.',\n",
        "  'output_2': 'I am available to answer any questions you may have about my rate or if you need to alter the scope of this project. Feel free to contact me if you have any queries or require any additional information.',\n",
-       "  'annotator': 'davinci003_3',\n",
-       "  'preference': 1}]"
+       "  'annotator': 'alpaca_eval_gpt4',\n",
+       "  'preference': 1.0,\n",
+       "  'price_per_example': 0.01287,\n",
+       "  'time_per_example': 0.7309945424397787,\n",
+       "  'raw_completion': \"[\\n    {'model': 'model_2', 'rank': 1},\\n    {'model': 'model_1', 'rank': 2}\\n]\"}]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -362,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "50354b51-12c5-4833-81af-549d78ef3dc7",
    "metadata": {},
    "outputs": [
@@ -385,7 +419,7 @@
        "   'I remember a time when I had to decide whether to stay in my hometown or move to a new city. It was a difficult decision because I had grown up in the town, and I was used to the familiarity of my childhood home. On the other hand, the new city had more job opportunities and a better environment that I thought would be beneficial for my future. After weighing the pros and cons, I made the decision to move to the new city. It was the right choice, as I was able to find a job I enjoyed and make some great friends in the new place.']}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -406,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "cc8557da-46fd-4906-a209-a02cc12eef9d",
    "metadata": {},
    "outputs": [
@@ -415,9 +449,18 @@
      "output_type": "stream",
      "text": [
       "INFO:root:Filtered unique instruction/input pairs: 4 -> 1\n",
-      "INFO:root:Annotating 0 examples with davinci003_3\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n"
+      "Annotation chunk:   0%|                                                       | 0/1 [00:00<?, ?it/s]INFO:root:Annotating 1 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Using `openai_completions` on 1 prompts using gpt-4.\n",
+      "INFO:root:Kwargs to completion: {'model': 'gpt-4', 'is_chat': True, 'temperature': 0}. num_procs=5\n",
+      "\n",
+      "prompt_batches:   0%|                                                         | 0/1 [00:00<?, ?it/s]\u001b[AINFO:root:Using OAI client number 1 out of 1.\n",
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "\n",
+      "prompt_batches: 100%|█████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.78s/it]\u001b[A\n",
+      "INFO:root:Completed 1 examples in 3.0 seconds.\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 1/1 [00:04<00:00,  4.54s/it]\n"
      ]
     }
    ],
@@ -427,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "6a55348a-a0ca-4fe1-b6d1-b9fa5d1c339b",
    "metadata": {},
    "outputs": [
@@ -439,11 +482,14 @@
        "  'input': '',\n",
        "  'output_1': \"I had to make a difficult decision a few years ago when I was offered a job that would require me to move to a different city. I had to weigh the pros and cons of this job offer, and consider what it would mean for me to leave my friends and family in order to take it. In the end, I decided to turn down the job offer since I wasn't ready to quit my current job, move to a different city, and leave my loved ones behind.\",\n",
        "  'output_2': \"I had to make a difficult decision when I was offered a job in a city that was significantly farther away from my friends and family. I weighed the pros and cons and consulted with people I trusted, but in the end I had to make the choice that was best for my future and my well-being. It was a difficult decision, but I'm glad I made the choice that allowed me to further my career and start my journey towards independence.\",\n",
-       "  'annotator': 'davinci003_3',\n",
-       "  'preference': 1}]"
+       "  'annotator': 'alpaca_eval_gpt4',\n",
+       "  'preference': 2.0,\n",
+       "  'price_per_example': 0.014759999999999999,\n",
+       "  'time_per_example': 2.95092511177063,\n",
+       "  'raw_completion': \"[\\n    {'model': 'model_2', 'rank': 1},\\n    {'model': 'model_1', 'rank': 2}\\n]\"}]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -491,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "68702d25-3a12-4de6-bef8-e21e79c8d113",
    "metadata": {},
    "outputs": [
@@ -500,10 +546,11 @@
      "output_type": "stream",
      "text": [
       "INFO:root:Filtered unique instruction/input pairs: 4 -> 1\n",
-      "INFO:root:Adding random noise to the labels p_label_flip=0.25.\n",
-      "INFO:root:Annotating 0 examples with davinci003_3\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n"
+      "Annotation chunk:   0%|                                                       | 0/1 [00:00<?, ?it/s]INFO:root:Adding random noise to the labels p_label_flip=0.25.\n",
+      "INFO:root:Annotating 0 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 1/1 [00:01<00:00,  1.46s/it]\n"
      ]
     }
    ],
@@ -513,7 +560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "1d663d65-5da5-40b5-a14b-f2f925649132",
    "metadata": {},
    "outputs": [
@@ -525,11 +572,14 @@
        "  'input': '',\n",
        "  'output_1': \"I had to make a difficult decision a few years ago when I was offered a job that would require me to move to a different city. I had to weigh the pros and cons of this job offer, and consider what it would mean for me to leave my friends and family in order to take it. In the end, I decided to turn down the job offer since I wasn't ready to quit my current job, move to a different city, and leave my loved ones behind.\",\n",
        "  'output_2': \"I had to make a difficult decision when I was offered a job in a city that was significantly farther away from my friends and family. I weighed the pros and cons and consulted with people I trusted, but in the end I had to make the choice that was best for my future and my well-being. It was a difficult decision, but I'm glad I made the choice that allowed me to further my career and start my journey towards independence.\",\n",
-       "  'annotator': 'davinci003_3',\n",
-       "  'preference': 1}]"
+       "  'annotator': 'alpaca_eval_gpt4',\n",
+       "  'preference': 2.0,\n",
+       "  'price_per_example': 0.014759999999999999,\n",
+       "  'time_per_example': 2.95092511177063,\n",
+       "  'raw_completion': \"[\\n    {'model': 'model_2', 'rank': 1},\\n    {'model': 'model_1', 'rank': 2}\\n]\"}]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -546,12 +596,12 @@
     "### Cost & time efficiency: avoiding duplicate annotation\n",
     "Often time you will find yourself reannotating examples that you already annotated. This is particularly true if you sample many times from the same model (eg to get pairwise preferences for training or to evaluate best-of-n) or if the instructions you are considering require short outputs => many models might give the same exact answer.\n",
     "\n",
-    "This means that you have to spend unecessary money and time. Thankfully `PairwiseAutoAnnotator` stores previous annotations and will reuse those. For example, let us reannotate the previous evaluation"
+    "This means that you have to spend unecessary money and time. Thankfully `PairwiseAnnotator` stores previous annotations and will reuse those. For example, let us reannotate the previous evaluation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "58d43c91-0ef4-417e-bbb2-ce585f6c35ba",
    "metadata": {},
    "outputs": [
@@ -559,9 +609,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:Annotating 0 examples with davinci003_3\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/test/annotations_seed0_configs.json.\n"
+      "Annotation chunk:   0%|                                                       | 0/1 [00:00<?, ?it/s]INFO:root:Annotating 0 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 1/1 [00:01<00:00,  1.45s/it]\n"
      ]
     }
    ],
@@ -571,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "cd5e9051-23fe-4294-9993-0c7afbc74495",
    "metadata": {},
    "outputs": [
@@ -582,11 +633,14 @@
        "  'input': '',\n",
        "  'output_1': \"Dear Friends, \\r\\n\\r\\nI hope this message finds you well. I'm excited to invite you to dinner on Friday. We'll meet at 7:00 PM at [location]. I look forward to seeing you there. \\r\\n\\r\\nBest,\\r\\n[Name]\",\n",
        "  'output_2': 'Dear Friends, \\n\\nI am writing to invite you all to a dinner on Friday evening. It is a casual affair, and I am looking forward to a fun evening catching up with you all. I am planning to make a selection of delicious dishes, ranging from appetizers to mains and desserts. There will be something for everyone to enjoy, and I am sure it will be a night to remember.\\n\\nThe dinner will be held at my place on Friday, April 17th at 7pm. If you are interested in joining me, please RSVP to this email by Thursday, April 16th. I am looking forward to seeing you all there! \\n\\nThank you, \\n\\n[Name]',\n",
-       "  'annotator': 'davinci003_3',\n",
-       "  'preference': 2}]"
+       "  'annotator': 'alpaca_eval_gpt4',\n",
+       "  'preference': 2.0,\n",
+       "  'price_per_example': 0.015269999999999999,\n",
+       "  'time_per_example': 0.7309945424397787,\n",
+       "  'raw_completion': \"[\\n    {'model': 'model_1', 'rank': 1},\\n    {'model': 'model_2', 'rank': 2}\\n]\"}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -617,12 +671,12 @@
    "id": "78922f60-a9aa-4383-b18d-c95a93c6546c",
    "metadata": {},
    "source": [
-    "Let's show how to get win rates from annotations using our actual pool of annotators"
+    "Let's show how to get win rates."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "826421f1-e644-42c9-9375-d8b08fb958ad",
    "metadata": {},
    "outputs": [],
@@ -632,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "93ffaa6c-9570-4384-b157-d6f95b6d90ba",
    "metadata": {},
    "outputs": [],
@@ -645,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "2e000d42-6c37-40c6-81ac-eef3d34a4816",
    "metadata": {},
    "outputs": [
@@ -653,360 +707,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:Creating the annotator from `annotator_pool_v0`.\n",
-      "INFO:root:Saving annotations to `/Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json`.\n"
-     ]
-    }
-   ],
-   "source": [
-    "annotator_pool = PairwiseAutoAnnotator()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "74b79ba1-aeb3-4dd0-8669-a171ba4a2c37",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:Annotating 18 examples with gpt4_1\n",
-      "INFO:root:Using `openai_completions` on 5 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 600, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 600, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [01:04<00:00, 12.94s/it]\n",
-      "INFO:root:Completed 5 examples in 64.8 seconds.\n",
-      "INFO:root:Annotating 20 examples with gpt4_2\n",
-      "INFO:root:Using `openai_completions` on 5 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:19<00:00,  3.89s/it]\n",
-      "INFO:root:Completed 5 examples in 19.6 seconds.\n",
-      "INFO:root:Annotating 19 examples with gpt4_3\n",
-      "INFO:root:Using `openai_completions` on 5 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:17<00:00,  3.54s/it]\n",
-      "INFO:root:Completed 5 examples in 17.8 seconds.\n",
-      "INFO:root:Annotating 19 examples with gpt4_4\n",
-      "INFO:root:Using `openai_completions` on 19 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19/19 [00:08<00:00,  2.17it/s]\n",
-      "INFO:root:Completed 19 examples in 8.9 seconds.\n",
-      "INFO:root:Annotating 14 examples with gpt4_5\n",
-      "INFO:root:Using `openai_completions` on 3 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:18<00:00,  6.20s/it]\n",
-      "INFO:root:Completed 3 examples in 18.7 seconds.\n",
-      "INFO:root:Annotating 23 examples with chatgpt_1\n",
-      "INFO:root:Using `openai_completions` on 23 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 50, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 50, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:05<00:00,  4.08it/s]\n",
-      "INFO:root:Completed 23 examples in 5.7 seconds.\n",
-      "INFO:root:Annotating 31 examples with chatgpt_2\n",
-      "INFO:root:Using `openai_completions` on 31 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 150, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 150, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:29<00:00,  1.06it/s]\n",
-      "INFO:root:Completed 31 examples in 29.5 seconds.\n",
-      "INFO:root:Annotating 14 examples with chatgpt_3\n",
-      "INFO:root:Using `openai_completions` on 14 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14/14 [00:04<00:00,  3.34it/s]\n",
-      "INFO:root:Completed 14 examples in 4.3 seconds.\n",
-      "INFO:root:Annotating 19 examples with chatgpt_4\n",
-      "INFO:root:Using `openai_completions` on 19 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19/19 [00:04<00:00,  3.95it/s]\n",
-      "INFO:root:Completed 19 examples in 4.9 seconds.\n",
-      "INFO:root:Annotating 10 examples with davinci003_1\n",
-      "INFO:root:Using `openai_completions` on 3 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0, 'logit_bias': {7: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0, 'logit_bias': {7: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.86s/it]\n",
-      "INFO:root:Completed 3 examples in 3.9 seconds.\n",
-      "INFO:root:Annotating 17 examples with davinci003_2\n",
-      "INFO:root:Using `openai_completions` on 17 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:04<00:00,  2.36s/it]\n",
-      "INFO:root:Completed 17 examples in 4.7 seconds.\n",
-      "INFO:root:Annotating 14 examples with davinci003_3\n",
-      "INFO:root:Using `openai_completions` on 3 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.94s/it]\n",
-      "INFO:root:Completed 3 examples in 4.0 seconds.\n",
-      "INFO:root:Annotating 24 examples with davinci003_4\n",
-      "INFO:root:Using `openai_completions` on 24 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:02<00:00,  1.00it/s]\n",
-      "INFO:root:Completed 24 examples in 3.0 seconds.\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'win_rate': 30.555555555555557,\n",
-       " 'standard_error': 2.838766377491875,\n",
-       " 'n_wins': 72,\n",
-       " 'n_wins_base': 170,\n",
-       " 'n_draws': 10,\n",
-       " 'n_total': 252}"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "annotated_sft = annotator_pool.annotate_head2head(outputs_1=outputs_baseline, outputs_2=outputs_sft)\n",
-    "pairwise_to_winrate(preferences=[a[\"preference\"] for a in annotated_sft])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "9c05eb80-0f24-4570-86ea-40da1a2a95a0",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:Annotating 19 examples with gpt4_1\n",
-      "INFO:root:Using `openai_completions` on 6 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 600, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 600, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [01:21<00:00, 13.50s/it]\n",
-      "INFO:root:Completed 6 examples in 81.1 seconds.\n",
-      "INFO:root:Annotating 19 examples with gpt4_2\n",
-      "INFO:root:Using `openai_completions` on 4 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:26<00:00,  6.53s/it]\n",
-      "INFO:root:Completed 4 examples in 26.2 seconds.\n",
-      "INFO:root:Annotating 20 examples with gpt4_3\n",
-      "INFO:root:Using `openai_completions` on 5 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:21<00:00,  4.33s/it]\n",
-      "INFO:root:Completed 5 examples in 21.7 seconds.\n",
-      "INFO:root:Annotating 19 examples with gpt4_4\n",
-      "INFO:root:Using `openai_completions` on 19 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19/19 [00:06<00:00,  2.92it/s]\n",
-      "INFO:root:Completed 19 examples in 6.6 seconds.\n",
-      "INFO:root:Annotating 14 examples with gpt4_5\n",
-      "INFO:root:Using `openai_completions` on 3 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:21<00:00,  7.08s/it]\n",
-      "INFO:root:Completed 3 examples in 21.3 seconds.\n",
-      "INFO:root:Annotating 24 examples with chatgpt_1\n",
-      "INFO:root:Using `openai_completions` on 24 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 50, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 50, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 24/24 [00:05<00:00,  4.35it/s]\n",
-      "INFO:root:Completed 24 examples in 5.6 seconds.\n",
-      "INFO:root:Annotating 31 examples with chatgpt_2\n",
-      "INFO:root:Using `openai_completions` on 31 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 150, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 150, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:31<00:00,  1.02s/it]\n",
-      "INFO:root:Completed 31 examples in 31.8 seconds.\n",
-      "INFO:root:Annotating 14 examples with chatgpt_3\n",
-      "INFO:root:Using `openai_completions` on 14 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14/14 [00:04<00:00,  3.47it/s]\n",
-      "INFO:root:Completed 14 examples in 4.1 seconds.\n",
-      "INFO:root:Annotating 20 examples with chatgpt_4\n",
-      "INFO:root:Using `openai_completions` on 20 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:04<00:00,  4.44it/s]\n",
-      "INFO:root:Completed 20 examples in 4.6 seconds.\n",
-      "INFO:root:Annotating 10 examples with davinci003_1\n",
-      "INFO:root:Using `openai_completions` on 3 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0, 'logit_bias': {7: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0, 'logit_bias': {7: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.14s/it]\n",
-      "INFO:root:Completed 3 examples in 3.1 seconds.\n",
-      "INFO:root:Annotating 18 examples with davinci003_2\n",
-      "INFO:root:Using `openai_completions` on 18 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:03<00:00,  2.00s/it]\n",
-      "INFO:root:Completed 18 examples in 4.0 seconds.\n",
-      "INFO:root:Annotating 15 examples with davinci003_3\n",
-      "INFO:root:Using `openai_completions` on 3 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:06<00:00,  6.22s/it]\n",
-      "INFO:root:Completed 3 examples in 6.2 seconds.\n",
-      "INFO:root:Annotating 26 examples with davinci003_4\n",
-      "INFO:root:Using `openai_completions` on 26 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.16s/it]\n",
-      "INFO:root:Completed 26 examples in 3.5 seconds.\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'win_rate': 47.42063492063492,\n",
-       " 'standard_error': 3.1454933555275866,\n",
-       " 'n_wins': 119,\n",
-       " 'n_wins_base': 132,\n",
-       " 'n_draws': 1,\n",
-       " 'n_total': 252}"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "annotated_rlhf = annotator_pool.annotate_head2head(outputs_1=outputs_baseline, outputs_2=outputs_rlhf)\n",
-    "pairwise_to_winrate(preferences=[a[\"preference\"] for a in annotated_rlhf])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "2ea9d199-08c4-4b94-9628-ef28a2c9e733",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5bdcc8327ff849ed8f8bdcd9142bf0ca",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading builder script:   0%|          | 0.00/7.26k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1be8be328d6a4a808480900ed3bfcc67",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading readme:   0%|          | 0.00/29.0 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading and preparing dataset alpaca_farm/alpaca_farm_evaluation to /Users/yanndubois/.cache/huggingface/datasets/tatsu-lab___alpaca_farm/alpaca_farm_evaluation/1.0.0/79d38dc3f12abd62869e376303b68092e8385769e22f05166fe96a3dac29a57a...\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9f543c1da09a4a799253caea4d4b86e3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading data:   0%|          | 0.00/600k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/yanndubois/.cache/huggingface/datasets/downloads/b8c17ea4d3dc2405e3c93ddaea295a6fe540c820557b668c6ac40cb66e1f606d\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Generating eval split: 0 examples [00:00, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset alpaca_farm downloaded and prepared to /Users/yanndubois/.cache/huggingface/datasets/tatsu-lab___alpaca_farm/alpaca_farm_evaluation/1.0.0/79d38dc3f12abd62869e376303b68092e8385769e22f05166fe96a3dac29a57a. Subsequent calls will reuse this data.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "498681bfc65044f5bb553857e9f6a85e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import datasets\n",
-    "from alpaca_farm import constants\n",
-    "outputs_baseline = datasets.load_dataset(\"tatsu-lab/alpaca_farm\",\n",
-    "                                             \"alpaca_farm_evaluation\",\n",
-    "                                             cache_dir=constants.DEFAULT_CACHE_DIR,\n",
-    "                                             )['eval']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "cd2138be-2cbe-432e-8bc5-54cb1a7439e2",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:Creating the annotator from `annotator_pool_v0`.\n",
-      "INFO:root:Saving annotations to `/Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json`.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json.\n"
+      "INFO:root:Creating the annotator from `alpaca_eval_gpt4`.\n",
+      "INFO:root:Saving annotations to `/Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json`.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n"
      ]
     }
    ],
@@ -1017,84 +720,87 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "3ba53eb9-d5a3-496d-8ae4-969b54ba2ee9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "outputs_2 = outputs_baseline.to_pandas()[:10]\n",
-    "outputs_2.output = outputs_2.output.str[:20]\n",
-    "outputs_1  = outputs_baseline.to_pandas()[:10]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "4bcc720a-3ac4-4228-86c1-a5fbace62c5c",
+   "id": "74b79ba1-aeb3-4dd0-8669-a171ba4a2c37",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:root:The length of outputs before and after merge are not the same. We have len(outputs_1)==\n",
-      "                    805, len(outputs_2)==10, and len(df_annotated)==10. \n",
-      "                    This means that there are missing examples or duplicates. We are taking a SQL inner join.\n",
-      "                    \n",
-      "INFO:root:Annotating 0 examples with gpt4_1\n",
-      "INFO:root:Annotating 2 examples with gpt4_2\n",
-      "INFO:root:Using `openai_completions` on 1 prompts using gpt-4-0314.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 250, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-4-0314', 'is_chat': True, 'max_tokens': 250, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:17<00:00, 17.74s/it]\n",
-      "INFO:root:Completed 1 examples in 17.8 seconds.\n",
-      "INFO:root:Annotating 0 examples with gpt4_3\n",
-      "INFO:root:Annotating 0 examples with gpt4_4\n",
-      "INFO:root:Annotating 0 examples with gpt4_5\n",
-      "INFO:root:Annotating 0 examples with chatgpt_1\n",
-      "INFO:root:Annotating 2 examples with chatgpt_2\n",
-      "INFO:root:Using `openai_completions` on 2 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 150, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 150, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100}}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:04<00:00,  2.11s/it]\n",
-      "INFO:root:Completed 2 examples in 4.3 seconds.\n",
-      "INFO:root:Annotating 1 examples with chatgpt_3\n",
-      "INFO:root:Using `openai_completions` on 1 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.67s/it]\n",
-      "INFO:root:Completed 1 examples in 1.8 seconds.\n",
-      "INFO:root:Annotating 1 examples with chatgpt_4\n",
-      "INFO:root:Using `openai_completions` on 1 prompts using gpt-3.5-turbo-0301.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'gpt-3.5-turbo-0301', 'is_chat': True, 'max_tokens': 20, 'temperature': 1.0, 'logit_bias': {21279: -100, 63295: -100, 4155: -100, 11995: -100, 25215: -100, 50344: -100, 59047: -100, 2196: -100, 2181: -100, 21704: -100, 19701: -100, 5207: 7, 320: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.51s/it]\n",
-      "INFO:root:Completed 1 examples in 1.6 seconds.\n",
-      "INFO:root:Annotating 1 examples with davinci003_1\n",
-      "INFO:root:Using `openai_completions` on 1 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0, 'logit_bias': {7: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0, 'logit_bias': {7: 7, 64: 7, 8: 7, 65: 7}}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.40s/it]\n",
-      "INFO:root:Completed 1 examples in 3.4 seconds.\n",
-      "INFO:root:Annotating 1 examples with davinci003_2\n",
-      "INFO:root:Using `openai_completions` on 1 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.14s/it]\n",
-      "INFO:root:Completed 1 examples in 1.2 seconds.\n",
-      "INFO:root:Annotating 2 examples with davinci003_3\n",
-      "INFO:root:Using `openai_completions` on 1 prompts using text-davinci-003.\n",
-      "INFO:root:Kwargs to completion: {'max_tokens': 200, 'temperature': 1.0}\n",
-      "INFO:root:Kwargs to completion: {'n': 1, 'model': 'text-davinci-003', 'is_chat': False, 'max_tokens': 200, 'temperature': 1.0}\n",
-      "prompt_batches: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.50s/it]\n",
-      "INFO:root:Completed 1 examples in 4.5 seconds.\n",
-      "INFO:root:Annotating 0 examples with davinci003_4\n",
-      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json.\n",
-      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_farm/src/alpaca_farm/auto_annotations/annotators/annotator_pool_v0/annotations_seed0_configs.json.\n"
+      "Annotation chunk:   0%|                                                       | 0/2 [00:00<?, ?it/s]INFO:root:Annotating 0 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk:  50%|███████████████████████▌                       | 1/2 [00:01<00:01,  1.51s/it]INFO:root:Annotating 0 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 2/2 [00:03<00:00,  1.53s/it]\n",
+      "INFO:root:drop 2 outputs that are not preferences\n",
+      "INFO:root:drop 2 outputs that are not preferences\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'win_rate': 34.0,\n",
+       " 'standard_error': 2.9343554261657316,\n",
+       " 'n_wins': 80,\n",
+       " 'n_wins_base': 160,\n",
+       " 'n_draws': 10,\n",
+       " 'n_total': 250,\n",
+       " 'discrete_win_rate': 34.0}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "annotated = annotator.annotate_head2head(outputs_1=outputs_baseline, outputs_2=outputs_2)"
+    "annotated_sft = annotator.annotate_head2head(outputs_1=outputs_baseline, outputs_2=outputs_sft)\n",
+    "pairwise_to_winrate(preferences=[a[\"preference\"] for a in annotated_sft])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "9c05eb80-0f24-4570-86ea-40da1a2a95a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Annotation chunk:   0%|                                                       | 0/2 [00:00<?, ?it/s]INFO:root:Annotating 0 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk:  50%|███████████████████████▌                       | 1/2 [00:01<00:01,  1.70s/it]INFO:root:Annotating 0 examples with alpaca_eval_gpt4\n",
+      "INFO:root:Saving all annotations to /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "INFO:root:Loading all annotations from /Users/yanndubois/Desktop/GitHub/alpaca_eval/src/alpaca_eval/evaluators_configs/alpaca_eval_gpt4/annotations_seed0_configs.json.\n",
+      "Annotation chunk: 100%|███████████████████████████████████████████████| 2/2 [00:03<00:00,  1.60s/it]\n",
+      "INFO:root:drop 1 outputs that are not preferences\n",
+      "INFO:root:drop 1 outputs that are not preferences\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'win_rate': 53.98406374501992,\n",
+       " 'standard_error': 3.145897059163296,\n",
+       " 'n_wins': 135,\n",
+       " 'n_wins_base': 115,\n",
+       " 'n_draws': 1,\n",
+       " 'n_total': 251,\n",
+       " 'discrete_win_rate': 53.98406374501992}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "annotated_rlhf = annotator.annotate_head2head(outputs_1=outputs_baseline, outputs_2=outputs_rlhf)\n",
+    "pairwise_to_winrate(preferences=[a[\"preference\"] for a in annotated_rlhf])"
    ]
   },
   {
@@ -1110,10 +816,7 @@
    "id": "4927636c-96f5-4125-a553-a5be011c2a42",
    "metadata": {},
    "source": [
-    "The most important argument to `PairwiseAutoAnnotator` is `annotators_config` which defines the pool of annotators (the API provider, the model, the prompt, and the decoding parameters) . We provide the following options out of the box:\n",
-    "- `annotators_config=\"annotators/annotator_pool_v0/configs.yaml\"`: ApacaFarm's default annotator pool\n",
-    "- `annotators_config=\"annotators/greedy_gpt4/configs.yaml\"`: Greedy GPT4 annotator\n",
-    "- `annotators_config=\"annotators/test/configs.yaml\"`: a faster text-davinci-003 annotator useful for testing\n",
+    "The most important argument to `PairwiseAnnotator` is `annotators_config` which defines the pool of annotators (the API provider, the model, the prompt, and the decoding parameters) . We provide many options out of the box.\n",
     "\n",
     "Here's the desciption of `annotators_config` from the docstring:\n",
     "```\n",
@@ -1130,51 +833,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "945ba06f-cc13-436f-83f0-f074f37ea2ea",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "davinci003_3 : # text-davinci-003_v1_b5-pairwise_temp=1.0\n",
-      "  prompt_template:\n",
-      "    with_inputs: \"annotator_pool_v0/text_b5_with_inputs.txt\"\n",
-      "    without_inputs: \"annotator_pool_v0/text_b5_without_inputs.txt\"\n",
-      "  fn_completions: \"openai_completions\"\n",
-      "  completions_kwargs:\n",
-      "    model_name: \"text-davinci-003\"\n",
-      "    max_tokens: 200\n",
-      "    temperature: 1.0\n",
-      "  completion_parser_kwargs:\n",
-      "    outputs_to_match:\n",
-      "      1: '\\n\\(a\\)'\n",
-      "      2: '\\n\\(b\\)'\n",
-      "  batch_size: 5\n"
-     ]
-    }
-   ],
-   "source": [
-    "!cat src/alpaca_farm/auto_annotations/annotators/test/configs.yaml"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "0233e875-ae40-4b53-bc6b-05cf0201bbf0",
    "metadata": {},
    "source": [
     "For more information, please refer to [AlpacaEval](https://github.com/tatsu-lab/alpaca_eval/tree/main). In our code, we directly use AlpacaEval, with a minor modification to separate instructions with and without inputs."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c27789c-e0db-49c8-83ad-efae843dbea9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ wandb
 torch>=1.13.1
 fire
 openai
-alpaca_eval>=0.5.3
+alpaca_eval>=0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ wandb
 torch>=1.13.1
 fire
 openai
-alpaca_eval>=0.2.8
+alpaca_eval>=0.5.3

--- a/src/alpaca_farm/auto_annotations/__init__.py
+++ b/src/alpaca_farm/auto_annotations/__init__.py
@@ -12,4 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .eval import PairwiseAutoAnnotator, alpaca_leaderboard
+# set the environment variable to use AlpacaEval1 IS_ALPACA_EVAL_2=False
+import os
+os.environ["IS_ALPACA_EVAL_2"] = "False"
+
+from .eval import alpaca_leaderboard, PairwiseAutoAnnotator

--- a/src/alpaca_farm/auto_annotations/eval.py
+++ b/src/alpaca_farm/auto_annotations/eval.py
@@ -1,252 +1,35 @@
-import json
-import logging
-from pathlib import Path
-from typing import Any, Optional, Sequence, Union
+
+import numpy as np
 
 import alpaca_eval.annotators as eval_annotators
-import alpaca_eval.utils as eval_utils
-import datasets
-import pandas as pd
-
-import alpaca_eval.annotators as eval_annotators
-import alpaca_eval.processors as eval_processors
-from alpaca_eval import metrics
-
-from .. import constants
+import alpaca_eval.utils as ae_utils
+import alpaca_eval.main as ae_main
 
 __all__ = ["alpaca_leaderboard", "PairwiseAutoAnnotator"]
 
-CURRENT_DIR = Path(__file__).parent
-ANNOTATORS_CONFIG_DIR = CURRENT_DIR / "annotators"
-DUMMY_EXAMPLE_NOINPUT = dict(instruction="Solve: 1+1=", output_1="2", output_2="3")
-DUMMY_EXAMPLE_INPUT = dict(instruction="Solve:", output_1="2", input="1+1=", output_2="3")
-
-
-PRECOMPUTED_LEADERBOARD = {
-    "annotator_pool_v0/configs.yaml": {
-        # Internal codename: rlhf_llama_7b_regen_v7_3ep_v12_ckpt_20
-        "RLHF PPO": {
-            "n_draws": 9.0,
-            "n_total": 805.0,
-            "n_wins": 392.0,
-            "n_wins_base": 404.0,
-            "standard_error": 1.753281981205392,
-            "win_rate": 49.25465838509317,
-        },
-        # Internal codename: sft_v6_52k_llama_7b_regen_v7_3ep_recover
-        "SFT 52k (Alpaca 7B)": {
-            "n_draws": 16.0,
-            "n_total": 805.0,
-            "n_wins": 312.0,
-            "n_wins_base": 477.0,
-            "standard_error": 1.707927043869429,
-            "win_rate": 39.75155279503105,
-        },
-        # Internal codename: sft_v6_llama_7b_regen_v7_3ep
-        "SFT 10k": {
-            "n_draws": 19.0,
-            "n_total": 802.0,
-            "n_wins": 278.00,
-            "n_wins_base": 505.00,
-            "standard_error": 1.67,
-            "win_rate": 35.85,
-        },
-        "Davinci001": {
-            "n_draws": 0.0,
-            "n_total": 805.0,
-            "n_wins": 201.0,
-            "n_wins_base": 604.0,
-            "standard_error": 1.5264851835334794,
-            "win_rate": 24.96894409937888,
-        },
-        "ChatGPT": {
-            "n_draws": 9.0,
-            "n_total": 805.0,
-            "n_wins": 503.0,
-            "n_wins_base": 293.0,
-            "standard_error": 1.6920642123984606,
-            "win_rate": 63.04347826086957,
-        },
-        "LLaMA 7B": {
-            "n_draws": 0.0,
-            "n_total": 775.0,
-            "n_wins": 98.0,
-            "n_wins_base": 677.0,
-            "standard_error": 1.1946348760380694,
-            "win_rate": 12.645161290322582,
-        },
-        "GPT4": {
-            "n_draws": 17.0,
-            "n_total": 804.0,
-            "n_wins": 631.0,
-            "n_wins_base": 156.0,
-            "standard_error": 1.4002932714785454,
-            "win_rate": 79.53980099502488,
-        },
-    }
-}
-
-
-# TODO: alpaca_leaderboard could also be replaced with alpaca_eval functions
+#! Important:
+# The leaderboard is different from teh paper because Davinci003 is depreciated. We now use AlpacaEval1 to
+# evaluate the models.AlpacaEval2 is cheaper and has will have more evaluated models, but the baseline is too stong
+# => models from AlpacaFarm will have very low scores.
 def alpaca_leaderboard(
-    path_or_all_outputs: Union[eval_utils.AnyData, eval_utils.AnyPath],
-    annotators_config: eval_utils.AnyPath = "annotator_pool_v0/configs.yaml",
-    name: str = "Current method",
-    is_add_reference_methods: bool = True,
-    is_print_metrics: bool = False,
-    **kwargs,
-) -> pd.DataFrame:
-    """Add the given model to the Alpaca leaderboard.
+        *args,
+        **kwargs,
+):
+    return ae_main.evaluate(*args,
+                           leaderboard_mode_to_print=["alpaca-farm-ppo-human", "alpaca-7b", "text_davinci_001",
+                                                      "gpt35_turbo_instruct", "alpaca-farm-ppo-sim-gpt4-20k"],
+                           **kwargs)
 
-    Parameters
-    ----------
-    path_or_all_outputs : str or list of dict
-        The outputs of the model to add to the leaderboard as a list of dictionaries, or a path to list of JSON. Each
-        dictionary (or row) should contain the following keys: `instruction`, `input`, and `output`.
-
-    annotators_config : str, optional
-        The path to the annotator's config file. For details see the docstring of `PairwiseAutoAnnotator`.
-
-    name : str, optional
-        The name of the model to add to the leaderboard.
-
-    is_add_reference_methods : bool, optional
-        Whether to add the Alpaca reference methods to the leaderboard.
-
-    is_print_metrics : bool, optional
-        Whether to print the metrics.
-
-    kwargs :
-        Additional arguments to pass to `PairwiseAutoAnnotator`.
-    """
-    try:
-        with open(path_or_all_outputs) as f:
-            all_outputs = json.load(f)
-            logging.info(f"Loaded outputs from {path_or_all_outputs}.")
-    except:
-        all_outputs = path_or_all_outputs
-
-    if is_add_reference_methods:
-        all_metrics = PRECOMPUTED_LEADERBOARD[annotators_config]
-    else:
-        all_metrics = dict()
-
-    outputs_baseline = datasets.load_dataset(
-        "tatsu-lab/alpaca_farm",
-        "alpaca_farm_evaluation",
-        cache_dir=constants.DEFAULT_CACHE_DIR,
-    )["eval"]
-
-    if len(all_outputs) != 805:
-        logging.warning(
-            f"""You gave {len(all_outputs)} outputs, but there are 805 examples in Alpaca Eval.
-        We are computing the metrics on all examples you gave."""
-        )
-
-    outputs_1 = eval_utils.load_or_convert_to_dataframe(outputs_baseline)
-    outputs_2 = eval_utils.load_or_convert_to_dataframe(all_outputs)
-    annotator = PairwiseAutoAnnotator(annotators_config=annotators_config, **kwargs)
-    annotated = annotator.annotate_head2head(outputs_1=outputs_1, outputs_2=outputs_2)
-    all_metrics[name] = metrics.pairwise_to_winrate(preferences=[a["preference"] for a in annotated])
-
-    df_results = pd.DataFrame(all_metrics).T.sort_values(by="win_rate", ascending=False)
-
-    if is_print_metrics:
-        print(df_results.to_string(float_format="%.2f"))
-    else:
-        return df_results
 
 
 class PairwiseAutoAnnotator(eval_annotators.PairwiseAnnotator):
-    def __init__(
-        self,
-        annotators_config: Union[eval_utils.AnyPath, list[dict[str, Any]]] = "annotator_pool_v0",
-        input_keys: Sequence[str] = ("instruction", "input"),
-        p_label_flip: Optional[float] = None,
-        base_dir: eval_utils.AnyPath = ANNOTATORS_CONFIG_DIR,
-        other_keys_to_keep: Sequence[str] = tuple(),
-        **kwargs,
-    ):
-        super().__init__(
-            annotators_config=annotators_config,
-            input_keys=input_keys,
-            p_label_flip=p_label_flip,
-            base_dir=base_dir,
-            other_keys_to_keep=other_keys_to_keep,
-            **kwargs,
-        )
-
-    @property
-    def SingleAnnotator(self):
-        return SinglePairwiseAutoAnnotator
-
-
-class SinglePairwiseAutoAnnotator(eval_annotators.SinglePairwiseAnnotator):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        for i, processor in enumerate(self.processors):
-            # you need to use a batch padder that separates inputs and no inputs
-            if isinstance(processor, eval_processors.PaddingForBatchesProcessor):
-                self.processors[i] = PaddingForBatchesProcessorInputNoinput(
-                    batch_size=self.batch_size,
-                    padding_example_input=DUMMY_EXAMPLE_INPUT,
-                    padding_example_noinput=DUMMY_EXAMPLE_NOINPUT,
-                )
-
-    def _get_prompt_template(self, prompt_template: dict[str, str]):
-        # prompt_template will now be a dictionary of prompt templates of len 2 (one with and one without input)
-        _get_prompt_template = super()._get_prompt_template
-        return {k: _get_prompt_template(prompt) for k, prompt in prompt_template.items()}
-
-    def _make_prompts(self, df_to_annotate, prompt_template=None):
-        if prompt_template is None:
-            prompt_template = self.prompt_template
-
-        arr_is_inputs = (df_to_annotate["input"] != "") & (df_to_annotate["input"].notnull())
-        df_with_inputs = df_to_annotate[arr_is_inputs]
-        df_without_inputs = df_to_annotate[~arr_is_inputs]
-
-        prompts, df = super()._make_prompts(
-            df_without_inputs,
-            prompt_template=prompt_template["without_inputs"],
-        )
-        if arr_is_inputs.any():
-            prompts_i, df_i = super()._make_prompts(
-                df_with_inputs,
-                prompt_template=prompt_template["with_inputs"],
-            )
-            prompts += prompts_i
-            df = pd.concat([df, df_i], axis=0, ignore_index=True)
-
-        return prompts, df
-
-
-class PaddingForBatchesProcessorInputNoinput(eval_processors.BaseProcessor):
-    def __init__(self, batch_size, padding_example_input: dict, padding_example_noinput: dict, **kwargs):
-        self.padded_noinput = eval_processors.PaddingForBatchesProcessor(
-            batch_size=batch_size, padding_example=padding_example_noinput, **kwargs
-        )
-        self.padded_input = eval_processors.PaddingForBatchesProcessor(
-            batch_size=batch_size, padding_example=padding_example_input, **kwargs
-        )
-        super().__init__(**kwargs)
-
-    def preprocess(self, df_to_annotate: pd.DataFrame) -> pd.DataFrame:
-        arr_is_inputs = (df_to_annotate["input"] != "") & (df_to_annotate["input"].notnull())
-        if arr_is_inputs.any():
-            # need to padd separately with and without inputs
-            padded_df_without_inputs = self.padded_noinput.preprocess(df_to_annotate[~arr_is_inputs].copy())
-            padded_df_with_inputs = self.padded_input.preprocess(df_to_annotate[arr_is_inputs].copy())
-
-            df_out = pd.concat([padded_df_without_inputs, padded_df_with_inputs], axis=0, ignore_index=True)
-        else:
-            df_out = self.padded_noinput.preprocess(df_to_annotate)
-
-        df_out["is_padding"] = df_out["is_padding"].astype(bool)
-
-        return df_out
-
-    def postprocess(self, df_to_annotate: pd.DataFrame) -> pd.DataFrame:
-        # independent of inputs
-        return self.padded_noinput.postprocess(df_to_annotate)
+    def __init__(self, *args, input_keys=("input", "instruction"), **kwargs):
+        super().__init__(*args, input_keys=input_keys, **kwargs)
+    def __call__(self, to_annotate, **decoding_kwargs):
+        df_to_annotate = ae_utils.convert_to_dataframe(to_annotate)
+        # merge input and instruction column into one. but only if input is not empty
+        merged_col = df_to_annotate["instruction"] + "\n\n" + df_to_annotate["input"]
+        df_to_annotate["instruction"] = np.where(df_to_annotate["input"] != "",
+                                                 merged_col,
+                                                 df_to_annotate["instruction"])
+        return super().__call__(df_to_annotate, **decoding_kwargs)

--- a/tests/test_auto_eval.py
+++ b/tests/test_auto_eval.py
@@ -16,7 +16,7 @@ def test_example():
                 "Friday. We'll meet at 7:00 PM at [location]. I look forward to seeing you there. \r\n\r\nBest,\r\n[Name]",
     'output_2': "Hey everyone! \n\nI'm hosting a dinner party this Friday night and I'd love for all of you to come "
                 "over. We'll have a delicious spread of food and some great conversations. \n\nLet me know if you can make it - I'd love to see you all there!\n\nCheers,\n[Your Name]",
-    'annotator': 'chatgpt_2',
+    'annotator': 'alpaca_eval_gpt4',
     'preference': 2}
     for k,v in expected_annotations.items():
         assert annotated[-1][k] == v


### PR DESCRIPTION
`text-davinci-003` is depreciated. To ensure that the codebase is still usable I'm switching to AlapcaEval annotations. 

Changes:
- [x] merge instruction and input (to be able to use AE 1). Note that we only do that for preferences, I did not modify the code for generations/inference of the analyzed models.
- [x] switch to AlpacaEval 1
- [x] test 
- [x] update annotation notebook
- [x] update AE dependencies
- [x] update readme

FYI @lxuechen 


closes #87
closes #85
closes #68