### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/src/alpaca_farm/common.py
+++ b/src/alpaca_farm/common.py
@@ -251,10 +251,9 @@ def flatten_dict(nested, sep=".", postprocess_fn=lambda *args: args):
 def unpack_dict(d: Dict, keys: Sequence[str], return_type: type = tuple) -> Union[Sequence, Dict]:
     if return_type in (tuple, list):
         return return_type(d[key] for key in keys)
-    elif return_type == dict:
+    if return_type == dict:
         return {key: d[key] for key in keys}
-    else:
-        raise ValueError(f"Unknown return_type: {return_type}")
+    raise ValueError(f"Unknown return_type: {return_type}")
 
 
 def merge_dict(dicts: Sequence[dict], merge_fn: Callable = lambda *args: args) -> dict:
@@ -295,9 +294,9 @@ def get_transformer_hidden_size(model: transformers.PreTrainedModel):
 def prepare_inputs(data: Union[torch.Tensor, Any], device: Union[str, int, torch.device]) -> Union[torch.Tensor, Any]:
     if isinstance(data, Mapping):
         return type(data)({k: prepare_inputs(v, device) for k, v in data.items()})  # noqa
-    elif isinstance(data, (tuple, list)):
+    if isinstance(data, (tuple, list)):
         return type(data)(prepare_inputs(v, device) for v in data)
-    elif isinstance(data, torch.Tensor):
+    if isinstance(data, torch.Tensor):
         return data.to(device)  # This can break with deepspeed.
     return data
 

--- a/src/alpaca_farm/flash_models/apex_patch.py
+++ b/src/alpaca_farm/flash_models/apex_patch.py
@@ -31,8 +31,7 @@ def apex_layernorm(ln_module, input_):
         return apex.normalization.fused_layer_norm.FusedLayerNormAffineFunction.apply(
             input_, ln_module.weight, ln_module.bias, ln_module.normalized_shape, ln_module.eps
         )
-    else:
-        return ln_module(input_)
+    return ln_module(input_)
 
 
 def apex_rmsnorm(ln_module, input_):
@@ -40,5 +39,4 @@ def apex_rmsnorm(ln_module, input_):
         return apex.normalization.fused_layer_norm.FusedRMSNormAffineFunction.apply(
             input_, ln_module.weight, ln_module.weight.size(), ln_module.variance_epsilon
         )
-    else:
-        return ln_module(input_)
+    return ln_module(input_)

--- a/src/alpaca_farm/flash_models/flash_llama.py
+++ b/src/alpaca_farm/flash_models/flash_llama.py
@@ -92,14 +92,14 @@ class LlamaAttention(modeling_llama.LlamaAttention):
                 )
                 past_key_value = (key_states, value_states)
             return attn_output, None, past_key_value
-        else:
-            return super(LlamaAttention, self).forward(  # noqa
-                hidden_states=hidden_states,
-                attention_mask=attention_mask_k,
-                position_ids=position_ids,
-                past_key_value=past_key_value,
-                use_cache=use_cache,
-            )
+
+        return super(LlamaAttention, self).forward(  # noqa
+            hidden_states=hidden_states,
+            attention_mask=attention_mask_k,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            use_cache=use_cache,
+        )
 
 
 class LlamaDecoderLayer(modeling_llama.LlamaDecoderLayer):

--- a/src/alpaca_farm/rl/kl_controller.py
+++ b/src/alpaca_farm/rl/kl_controller.py
@@ -60,5 +60,4 @@ def make_kl_controller(args, accelerator=None):
             k_beta=args.k_beta,
             accelerator=accelerator,
         )
-    else:
-        return FixedKLController(kl_coef=args.kl_coef)
+    return FixedKLController(kl_coef=args.kl_coef)

--- a/src/alpaca_farm/utils.py
+++ b/src/alpaca_farm/utils.py
@@ -157,14 +157,13 @@ def stable_resize_token_embeddings(model: transformers.PreTrainedModel, target_s
 def convert_str_dtype_to_torch_dtype(str_dtype: Optional[str]):
     if str_dtype in ("single", "float32", "float", "fp32", None):
         return torch.float
-    elif str_dtype in ("half", "float16", "fp16"):
+    if str_dtype in ("half", "float16", "fp16"):
         return torch.float16
-    elif str_dtype in ("bfloat16", "bf16"):
+    if str_dtype in ("bfloat16", "bf16"):
         return torch.bfloat16
-    elif str_dtype in ("double", "float64"):
+    if str_dtype in ("double", "float64"):
         return torch.float64
-    else:
-        raise ValueError(f"Unknown dtype: {str_dtype}")
+    raise ValueError(f"Unknown dtype: {str_dtype}")
 
 
 def manual_seed(args_or_seed: Union[int, argparse.Namespace], fix_cudnn=False):


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.